### PR TITLE
Add nvr (neovim-remote) to list of editors

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -138,6 +138,8 @@ function getArgumentsForLineNumber(
     case 'notepad++':
       return ['-n' + lineNumber, '-c' + colNumber, fileName];
     case 'vim':
+    case 'nvr':
+            return ['+' + lineNumber,  fileName];
     case 'mvim':
     case 'joe':
     case 'gvim':


### PR DESCRIPTION
[neovim-remote](https://github.com/mhinz/neovim-remote) (`nvr`) is a tool to open files from an external command to an existing neovim session. If the neovim session which is used for the CRA project is started with `NVIM_LISTEN_ADDRESS=/tmp/nvimsocket nvim`, `nvr` can be used from the CRA error page to jump directly to the file/line if an error occurs.
To use it one only has to set the environment var:
`REACT_EDITOR=nvr`

Steps to test:
1. install `nvr`
2. start neovim session wit `NVIM_LISTEN_ADDRESS=/tmp/nvimsocket nvim`
3. set REACT_EDITOR=nvr
4. open development project (`yarn start`) in Browser and produce error
5. click on error message

Result:
the file containing the error is opened in the existing neovim session. If the file is already open in a buffer, jump to the line containing the error.
